### PR TITLE
Incorporate Rails PR #48272

### DIFF
--- a/lib/active_record/connection_adapters/trilogy_adapter.rb
+++ b/lib/active_record/connection_adapters/trilogy_adapter.rb
@@ -398,6 +398,9 @@ module ActiveRecord
         end
 
         def translate_exception(exception, message:, sql:, binds:)
+          if exception.is_a?(::Trilogy::TimeoutError) && !exception.error_code
+            return ActiveRecord::AdapterTimeout.new(message, sql: sql, binds: binds)
+          end
           error_code = exception.error_code if exception.respond_to?(:error_code)
 
           ::TrilogyAdapter::LostConnectionExceptionTranslator.

--- a/lib/trilogy_adapter/errors.rb
+++ b/lib/trilogy_adapter/errors.rb
@@ -4,6 +4,8 @@ if ActiveRecord.version < ::Gem::Version.new('6.1.a') # ActiveRecord <= 6.0 supp
   module ::ActiveRecord
     class QueryAborted < ::ActiveRecord::StatementInvalid
     end
+    class AdapterTimeout < ::ActiveRecord::QueryAborted
+    end
   end
 end
 

--- a/test/lib/active_record/connection_adapters/trilogy_adapter_test.rb
+++ b/test/lib/active_record/connection_adapters/trilogy_adapter_test.rb
@@ -772,6 +772,17 @@ class ActiveRecord::ConnectionAdapters::TrilogyAdapterTest < TestCase
     assert_equal 123, @adapter.error_number(exception)
   end
 
+  test "read timeout raises ActiveRecord::AdapterTimeout" do
+    ActiveRecord::Base.establish_connection(@configuration.merge("read_timeout" => 1))
+
+    error = assert_raises(ActiveRecord::AdapterTimeout) do
+      ActiveRecord::Base.connection.execute("SELECT SLEEP(2)")
+    end
+    assert_kind_of ActiveRecord::QueryAborted, error
+
+    assert_equal Trilogy::TimeoutError, error.cause.class
+  end
+
   test "schema cache works without querying DB" do
     adapter = trilogy_adapter
     adapter.schema_cache = adapter.schema_cache.class.load_from(@schema_cache_fixture_path)


### PR DESCRIPTION
Per @casperisfine:
Prior to this patch it would translate it to InvalidStatement which is the catch all and is hard to work with.
