### PR TITLE
Incorporate Rails PR #48111

### DIFF
--- a/lib/active_record/connection_adapters/trilogy_adapter.rb
+++ b/lib/active_record/connection_adapters/trilogy_adapter.rb
@@ -151,7 +151,7 @@ module ActiveRecord
           when ER_ACCESS_DENIED_ERROR
             ActiveRecord::DatabaseConnectionError.username_error(config[:username])
           else
-            if error.message.match?(/TRILOGY_DNS_ERROR/)
+            if error.message.include?("TRILOGY_DNS_ERROR")
               ActiveRecord::DatabaseConnectionError.hostname_error(config[:host])
             else
               ActiveRecord::ConnectionNotEstablished.new(error.message)


### PR DESCRIPTION
Per @adrianna-chang-shopify:

Using `#include?` with a regular expression produces `TypeError: no implicit conversion of Regexp into String`

Note that the external adapter currently [uses #match?](https://github.com/github/activerecord-trilogy-adapter/blob/main/lib/active_record/connection_adapters/trilogy_adapter.rb#L104), but Rubocop prefers `#include?` with a String instead.
