### PR TITLE
Incorporate Rails PR #47974

### DIFF
--- a/lib/active_record/connection_adapters/trilogy_adapter.rb
+++ b/lib/active_record/connection_adapters/trilogy_adapter.rb
@@ -276,7 +276,11 @@ module ActiveRecord
       end
 
       def discard!
-        self.connection = nil
+        super
+        unless connection.nil?
+          connection.discard!
+          self.connection = nil
+        end
       end
 
       def each_hash(result)


### PR DESCRIPTION
Per @adrianna-chang-shopify:

Go through the `Trilogy#discard!` method added in https://github.com/trilogy-libraries/trilogy/pull/65 to ensure that forked connections can be discarded cleanly when calling `TrilogyAdapter#discard!`. We should also call `super` in `discard!`.