### PR TITLE
Incorporate Rails PR #48054 (Review me first!!)

### DIFF
--- a/lib/active_record/connection_adapters/trilogy/database_statements.rb
+++ b/lib/active_record/connection_adapters/trilogy/database_statements.rb
@@ -1,0 +1,124 @@
+# frozen_string_literal: true
+
+module ActiveRecord
+  module ConnectionAdapters
+    module Trilogy
+      module DatabaseStatements
+        READ_QUERY = ActiveRecord::ConnectionAdapters::AbstractAdapter.build_read_query_regexp(
+          :desc, :describe, :set, :show, :use
+        ) # :nodoc:
+        private_constant :READ_QUERY
+
+        HIGH_PRECISION_CURRENT_TIMESTAMP = Arel.sql("CURRENT_TIMESTAMP(6)").freeze # :nodoc:
+        private_constant :HIGH_PRECISION_CURRENT_TIMESTAMP
+
+        def write_query?(sql) # :nodoc:
+          !READ_QUERY.match?(sql)
+        rescue ArgumentError # Invalid encoding
+          !READ_QUERY.match?(sql.b)
+        end
+
+        def explain(arel, binds = [])
+          sql     = "EXPLAIN #{to_sql(arel, binds)}"
+          start   = Process.clock_gettime(Process::CLOCK_MONOTONIC)
+          result  = internal_exec_query(sql, "EXPLAIN", binds)
+          elapsed = Process.clock_gettime(Process::CLOCK_MONOTONIC) - start
+
+          MySQL::ExplainPrettyPrinter.new.pp(result, elapsed)
+        end
+
+        def select_all(*, **) # :nodoc:
+          result = super
+          with_trilogy_connection do |conn|
+            conn.next_result while conn.more_results_exist?
+          end
+          result
+        end
+
+        def exec_query(sql, name = "SQL", binds = [], prepare: false, **kwargs)
+          internal_exec_query(sql, name, binds, prepare: prepare, **kwargs)
+        end
+
+        def internal_exec_query(sql, name = "SQL", binds = [], prepare: false, async: false) # :nodoc:
+          sql = transform_query(sql)
+          check_if_write_query(sql)
+          mark_transaction_written_if_write(sql)
+
+          result = raw_execute(sql, name, async: async)
+          ActiveRecord::Result.new(result.fields, result.to_a)
+        end
+
+        def exec_insert(sql, name, binds, pk = nil, sequence_name = nil, returning: nil) # :nodoc:
+          sql = transform_query(sql)
+          check_if_write_query(sql)
+          mark_transaction_written_if_write(sql)
+
+          raw_execute(to_sql(sql, binds), name)
+        end
+
+        def exec_delete(sql, name = nil, binds = []) # :nodoc:
+          sql = transform_query(sql)
+          check_if_write_query(sql)
+          mark_transaction_written_if_write(sql)
+
+          result = raw_execute(to_sql(sql, binds), name)
+          result.affected_rows
+        end
+
+        alias :exec_update :exec_delete # :nodoc:
+
+        def high_precision_current_timestamp
+          HIGH_PRECISION_CURRENT_TIMESTAMP
+        end
+
+        private
+          if ActiveRecord.version < ::Gem::Version.new('7.0.a') # ActiveRecord <= 6.1 support
+            def raw_execute(sql, name, uses_transaction: true, **_kwargs)
+              # Same as mark_transaction_written_if_write(sql)
+              transaction = current_transaction
+              if transaction.respond_to?(:written) && transaction.open?
+                transaction.written ||= write_query?(sql)
+              end
+
+              log(sql, name) do
+                with_trilogy_connection(uses_transaction: uses_transaction) do |conn|
+                  sync_timezone_changes(conn)
+                  conn.query(sql)
+                end
+              end
+            end
+
+            def transform_query(sql); sql; end
+            def check_if_write_query(*args); end
+
+            if ActiveRecord.version < ::Gem::Version.new('6.1.a') # ActiveRecord <= 6.0 support
+              def mark_transaction_written_if_write(*args); end
+            end
+          else # ActiveRecord 7.0 support
+            def raw_execute(sql, name, uses_transaction: true, async: false, allow_retry: false)
+              mark_transaction_written_if_write(sql)
+              log(sql, name, async: async) do
+                with_trilogy_connection(uses_transaction: uses_transaction, allow_retry: allow_retry) do |conn|
+                  sync_timezone_changes(conn)
+                  conn.query(sql)
+                end
+              end
+            end
+          end
+
+          def last_inserted_id(result)
+            result.last_insert_id
+          end
+
+          def sync_timezone_changes(conn)
+            # Sync any changes since connection last established.
+            if default_timezone == :local
+              conn.query_flags |= ::Trilogy::QUERY_FLAGS_LOCAL_TIMEZONE
+            else
+              conn.query_flags &= ~::Trilogy::QUERY_FLAGS_LOCAL_TIMEZONE
+            end
+          end
+      end
+    end
+  end
+end

--- a/lib/active_record/connection_adapters/trilogy_adapter.rb
+++ b/lib/active_record/connection_adapters/trilogy_adapter.rb
@@ -4,6 +4,7 @@ require "trilogy"
 require "active_record/connection_adapters/abstract_mysql_adapter"
 
 require "active_record/tasks/trilogy_database_tasks"
+require "active_record/connection_adapters/trilogy/database_statements"
 require "trilogy_adapter/lost_connection_exception_translator"
 
 module ActiveRecord
@@ -59,78 +60,26 @@ module ActiveRecord
 
   module ConnectionAdapters
     class TrilogyAdapter < ::ActiveRecord::ConnectionAdapters::AbstractMysqlAdapter
-      module DatabaseStatements
-        READ_QUERY = ActiveRecord::ConnectionAdapters::AbstractAdapter.build_read_query_regexp(
-          :desc, :describe, :set, :show, :use
-        ) # :nodoc:
-        private_constant :READ_QUERY
-
-        HIGH_PRECISION_CURRENT_TIMESTAMP = Arel.sql("CURRENT_TIMESTAMP(6)").freeze # :nodoc:
-        private_constant :HIGH_PRECISION_CURRENT_TIMESTAMP
-
-        def write_query?(sql) # :nodoc:
-          !READ_QUERY.match?(sql)
-        rescue ArgumentError # Invalid encoding
-          !READ_QUERY.match?(sql.b)
-        end
-
-        def explain(arel, binds = [])
-          sql     = "EXPLAIN #{to_sql(arel, binds)}"
-          start   = Process.clock_gettime(Process::CLOCK_MONOTONIC)
-          result  = exec_query(sql, "EXPLAIN", binds)
-          elapsed = Process.clock_gettime(Process::CLOCK_MONOTONIC) - start
-
-          MySQL::ExplainPrettyPrinter.new.pp(result, elapsed)
-        end
-
-        def exec_query(sql, name = "SQL", binds = [], prepare: false, async: false)
-          result = execute(sql, name, async: async)
-          ActiveRecord::Result.new(result.fields, result.to_a)
-        end
-
-        alias exec_without_stmt exec_query
-
-        def exec_insert(sql, name, binds, pk = nil, sequence_name = nil)
-          execute(to_sql(sql, binds), name)
-        end
-
-        def exec_delete(sql, name = nil, binds = [])
-          result = execute(to_sql(sql, binds), name)
-          result.affected_rows
-        end
-
-        alias :exec_update :exec_delete
-
-        def high_precision_current_timestamp
-          HIGH_PRECISION_CURRENT_TIMESTAMP
-        end
-
-        private
-          def last_inserted_id(result)
-            result.last_insert_id
-          end
-      end
-
       ER_BAD_DB_ERROR = 1049
       ER_ACCESS_DENIED_ERROR = 1045
 
       ADAPTER_NAME = "Trilogy"
 
-      include DatabaseStatements
+      include Trilogy::DatabaseStatements
 
       SSL_MODES = {
-        SSL_MODE_DISABLED: Trilogy::SSL_DISABLED,
-        SSL_MODE_PREFERRED: Trilogy::SSL_PREFERRED_NOVERIFY,
-        SSL_MODE_REQUIRED: Trilogy::SSL_REQUIRED_NOVERIFY,
-        SSL_MODE_VERIFY_CA: Trilogy::SSL_VERIFY_CA,
-        SSL_MODE_VERIFY_IDENTITY: Trilogy::SSL_VERIFY_IDENTITY
+        SSL_MODE_DISABLED: ::Trilogy::SSL_DISABLED,
+        SSL_MODE_PREFERRED: ::Trilogy::SSL_PREFERRED_NOVERIFY,
+        SSL_MODE_REQUIRED: ::Trilogy::SSL_REQUIRED_NOVERIFY,
+        SSL_MODE_VERIFY_CA: ::Trilogy::SSL_VERIFY_CA,
+        SSL_MODE_VERIFY_IDENTITY: ::Trilogy::SSL_VERIFY_IDENTITY
       }.freeze
 
       class << self
         def new_client(config)
           config[:ssl_mode] = parse_ssl_mode(config[:ssl_mode]) if config[:ssl_mode]
           ::Trilogy.new(config)
-        rescue Trilogy::ConnectionError, Trilogy::ProtocolError => error
+        rescue ::Trilogy::ConnectionError, ::Trilogy::ProtocolError => error
           raise translate_connect_error(config, error)
         end
 
@@ -220,41 +169,11 @@ module ActiveRecord
         end
       end
 
-      if ActiveRecord.version < ::Gem::Version.new('7.0.a') # ActiveRecord <= 6.1 support
-        def raw_execute(sql, name, uses_transaction: true, **_kwargs)
-          # Same as mark_transaction_written_if_write(sql)
-          transaction = current_transaction
-          if transaction.respond_to?(:written) && transaction.open?
-            transaction.written ||= write_query?(sql)
-          end
+      def execute(sql, name = nil, allow_retry: false, **kwargs)
+        sql = transform_query(sql)
+        check_if_write_query(sql)
 
-          log(sql, name) do
-            with_trilogy_connection(uses_transaction: uses_transaction) do |conn|
-              sync_timezone_changes(conn)
-              conn.query(sql)
-            end
-          end
-        end
-
-        def execute(sql, name = nil, **_kwargs)
-          raw_execute(sql, name, **_kwargs)
-        end
-      else # ActiveRecord 7.0 support
-        def raw_execute(sql, name, uses_transaction: true, async: false, allow_retry: false)
-          mark_transaction_written_if_write(sql)
-          log(sql, name, async: async) do
-            with_trilogy_connection(uses_transaction: uses_transaction, allow_retry: allow_retry) do |conn|
-              sync_timezone_changes(conn)
-              conn.query(sql)
-            end
-          end
-        end
-
-        def execute(sql, name = nil, **kwargs)
-          sql = transform_query(sql)
-          check_if_write_query(sql)
-          super
-        end
+        raw_execute(sql, name, allow_retry: allow_retry, **kwargs)
       end
 
       def active?
@@ -279,28 +198,28 @@ module ActiveRecord
         self.connection = nil
       end
 
-      def each_hash(result)
-        return to_enum(:each_hash, result) unless block_given?
+      private
+        def each_hash(result)
+          return to_enum(:each_hash, result) unless block_given?
 
-        keys = result.fields.map(&:to_sym)
-        result.rows.each do |row|
-          hash = {}
-          idx = 0
-          row.each do |value|
-            hash[keys[idx]] = value
-            idx += 1
+          keys = result.fields.map(&:to_sym)
+          result.rows.each do |row|
+            hash = {}
+            idx = 0
+            row.each do |value|
+              hash[keys[idx]] = value
+              idx += 1
+            end
+            yield hash
           end
-          yield hash
+
+          nil
         end
 
-        nil
-      end
+        def error_number(exception)
+          exception.error_code if exception.respond_to?(:error_code)
+        end
 
-      def error_number(exception)
-        exception.error_code if exception.respond_to?(:error_code)
-      end
-
-      private
         attr_accessor :connection
 
         def connect
@@ -311,15 +230,6 @@ module ActiveRecord
           connection&.close
           self.connection = nil
           connect
-        end
-
-        def sync_timezone_changes(conn)
-          # Sync any changes since connection last established.
-          if default_timezone == :local
-            conn.query_flags |= ::Trilogy::QUERY_FLAGS_LOCAL_TIMEZONE
-          else
-            conn.query_flags &= ~::Trilogy::QUERY_FLAGS_LOCAL_TIMEZONE
-          end
         end
 
         def execute_batch(statements, name = nil)
@@ -342,11 +252,11 @@ module ActiveRecord
           end
 
           with_trilogy_connection do |conn|
-            conn.set_server_option(Trilogy::SET_SERVER_MULTI_STATEMENTS_ON)
+            conn.set_server_option(::Trilogy::SET_SERVER_MULTI_STATEMENTS_ON)
 
             yield
           ensure
-            conn.set_server_option(Trilogy::SET_SERVER_MULTI_STATEMENTS_OFF)
+            conn.set_server_option(::Trilogy::SET_SERVER_MULTI_STATEMENTS_OFF)
           end
         end
 

--- a/test/lib/active_record/connection_adapters/trilogy_adapter_test.rb
+++ b/test/lib/active_record/connection_adapters/trilogy_adapter_test.rb
@@ -280,16 +280,16 @@ class ActiveRecord::ConnectionAdapters::TrilogyAdapterTest < TestCase
     assert_nil adapter.discard!
   end
 
-  test "#exec_query answers result with valid query" do
-    result = @adapter.exec_query "SELECT * FROM posts;"
+  test "#internal_exec_query answers result with valid query" do
+    result = @adapter.internal_exec_query "SELECT * FROM posts;"
 
     assert_equal %w[id author_id title body kind created_at updated_at], result.columns
     assert_equal [], result.rows
   end
 
-  test "#exec_query fails with invalid query" do
+  test "#internal_exec_query fails with invalid query" do
     assert_raises_with_message ActiveRecord::StatementInvalid, /'trilogy_test.bogus' doesn't exist/ do
-      @adapter.exec_query "SELECT * FROM bogus;"
+      @adapter.internal_exec_query "SELECT * FROM bogus;"
     end
   end
 
@@ -745,7 +745,7 @@ class ActiveRecord::ConnectionAdapters::TrilogyAdapterTest < TestCase
     @adapter.execute "INSERT INTO posts (title, kind, body, created_at, updated_at) VALUES ('test', 'example', 'content', NOW(), NOW());"
     result = @adapter.execute "SELECT * FROM posts;"
 
-    @adapter.each_hash(result) do |row|
+    @adapter.send(:each_hash, result) do |row|
       assert_equal "test", row[:title]
     end
   end
@@ -753,14 +753,14 @@ class ActiveRecord::ConnectionAdapters::TrilogyAdapterTest < TestCase
   test "#each_hash returns an enumarator of symbolized result rows when no block is given" do
     @adapter.execute "INSERT INTO posts (title, kind, body, created_at, updated_at) VALUES ('test', 'example', 'content', NOW(), NOW());"
     result = @adapter.execute "SELECT * FROM posts;"
-    rows_enum = @adapter.each_hash result
+    rows_enum = @adapter.send(:each_hash, result)
 
     assert_equal "test", rows_enum.next[:title]
   end
 
   test "#each_hash returns empty array when results is empty" do
     result = @adapter.execute "SELECT * FROM posts;"
-    rows = @adapter.each_hash result
+    rows = @adapter.send(:each_hash, result)
 
     assert_empty rows.to_a
   end
@@ -769,7 +769,7 @@ class ActiveRecord::ConnectionAdapters::TrilogyAdapterTest < TestCase
     exception = Minitest::Mock.new
     exception.expect :error_code, 123
 
-    assert_equal 123, @adapter.error_number(exception)
+    assert_equal 123, @adapter.send(:error_number, exception)
   end
 
   test "schema cache works without querying DB" do


### PR DESCRIPTION
(This also attempts to have all method placement and naming to be as similar as possible to how things are laid out with the Trilogy adapter implementation found in Rails 7.1)

Per @casperisfine:

Stop using `#execute` as an internal method as it forces us to expose private parameters that aren't properly documented.

Also do some minor cleanup in the recently merged TrilogyAdapter to make it more consistent with other adapters.