### PR TITLE
Remove translation of exception on reconnect

### DIFF
--- a/lib/active_record/connection_adapters/trilogy_adapter.rb
+++ b/lib/active_record/connection_adapters/trilogy_adapter.rb
@@ -207,8 +207,6 @@ module ActiveRecord
         @lock.synchronize do
           disconnect!
           connect
-        rescue StandardError => original_exception
-          raise translate_exception_class(original_exception, nil, nil)
         end
       end
 

--- a/test/lib/active_record/connection_adapters/trilogy_adapter_test.rb
+++ b/test/lib/active_record/connection_adapters/trilogy_adapter_test.rb
@@ -188,8 +188,8 @@ class ActiveRecord::ConnectionAdapters::TrilogyAdapterTest < TestCase
       Trilogy.stub(:new, -> _ { raise Trilogy::BaseError.new }) do
         adapter.reconnect!
       end
-    rescue ActiveRecord::StatementInvalid => ex
-      assert_instance_of Trilogy::BaseError, ex.cause
+    rescue Trilogy::BaseError => ex
+      assert_instance_of Trilogy::BaseError, ex
     else
       flunk "Expected Trilogy::BaseError to be raised"
     end


### PR DESCRIPTION
This translation logic breaks Rails parallel tests, because that explicitly rescues the underlying ActiveRecord::NoDatabaseError. This means it fails all tests when running with parallel tests.

Based on Rails upstream, this translation is done there either so this drops it here as well. One test had to be slightly updated for this. But that test is also deleted already on upstream Rails.

WIth this change, we can successfully run tests against our Rails app with Trilogy instead of `mysql2`. 