### PR TITLE
Incorporate Rails PR #48112

### DIFF
--- a/lib/active_record/connection_adapters/trilogy_adapter.rb
+++ b/lib/active_record/connection_adapters/trilogy_adapter.rb
@@ -347,6 +347,15 @@ module ActiveRecord
           end
         end
 
+        def default_insert_value(column)
+          super unless column.auto_increment?
+        end
+
+        # https://mariadb.com/kb/en/analyze-statement/
+        def analyze_without_explain?
+          mariadb? && database_version >= "10.1.0"
+        end
+
         ActiveRecord::Type.register(:immutable_string, adapter: :trilogy) do |_, **args|
           Type::ImmutableString.new(true: "1", false: "0", **args)
         end


### PR DESCRIPTION
This PR establishes these three methods which are present in the AR 7.1 version of the Trilogy adapter, but so far have been absent from ARTA:

* `#write_query?`
* `#explain`
* `#default_insert_value` (which is private, and gets called from the public method `#insert_fixture`)
