### PR TITLE
Fixes #54 - Apply connection configuration

### DIFF
--- a/lib/active_record/connection_adapters/trilogy_adapter.rb
+++ b/lib/active_record/connection_adapters/trilogy_adapter.rb
@@ -297,6 +297,7 @@ module ActiveRecord
 
         def connect
           self.connection = self.class.new_client(@config)
+          configure_connection
         end
 
         def reconnect

--- a/test/lib/active_record/connection_adapters/trilogy_adapter_test.rb
+++ b/test/lib/active_record/connection_adapters/trilogy_adapter_test.rb
@@ -874,6 +874,12 @@ class ActiveRecord::ConnectionAdapters::TrilogyAdapterTest < TestCase
     assert adapter.active?
   end
 
+  test "sql_mode is applied correctly" do
+    adapter = trilogy_adapter(variables: { sql_mode: "STRICT_ALL_TABLES" })
+    current_sql_mode = adapter.execute('SELECT @@SESSION.sql_mode;').rows.first
+    assert_equal current_sql_mode, ["STRICT_ALL_TABLES"]
+  end
+
   def trilogy_adapter_with_connection(connection, **config_overrides)
     ActiveRecord::ConnectionAdapters::TrilogyAdapter
       .new(connection, nil, {}, @configuration.merge(config_overrides))


### PR DESCRIPTION
This is pursuant to issue #54 identified by @tmimura39 regarding applying connection configuration. Tomohiko indicates:

> It seems that various settings including **sql_mode** are not applied correctly because [configure_connection](https://github.com/rails/rails/blob/593893c901f87b4ed205751f72df41519b4d2da3/activerecord/lib/active_record/connection_adapters/abstract_mysql_adapter.rb#L776) is not executed.
...
> trilogy applies the default sql_mode.

As such, here is a fix which strives to adhere as closely as possible to how connection configuration behaviour is implemented in Rails 7.1.