### PR TITLE
Incorporate Rails PR #48068

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,16 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
 
 ## [Unreleased]
 
+### Changed
+
+- Remove translation of exception on reconnect. #49
+- Backport Rails 7.1a refactors and tweaks. #50, #51, #57, #58, #59
+
+### Fixed
+
+- Fix #53 - Implement dbconsole support. #55
+- Fix #54 - Apply connection configuration. #56
+
 ## 3.1.0
 
 ### Changed

--- a/lib/active_record/connection_adapters/trilogy/database_statements.rb
+++ b/lib/active_record/connection_adapters/trilogy/database_statements.rb
@@ -122,11 +122,11 @@ module ActiveRecord
             end
           end
 
-          def raw_execute(sql, name, async: false, uses_transaction: true)
+          def raw_execute(sql, name, async: false, materialize_transactions: true)
             log_kwargs = {}
             log_kwargs[:async] = async if ActiveRecord.version >= ::Gem::Version.new('7.0.a')
             log(sql, name, **log_kwargs) do
-              with_trilogy_connection(uses_transaction: uses_transaction) do |conn|
+              with_trilogy_connection(materialize_transactions: materialize_transactions) do |conn|
                 sync_timezone_changes(conn)
                 conn.query(sql)
               end

--- a/lib/active_record/connection_adapters/trilogy_adapter.rb
+++ b/lib/active_record/connection_adapters/trilogy_adapter.rb
@@ -188,7 +188,7 @@ module ActiveRecord
       end
 
       def quote_string(string)
-        with_trilogy_connection(allow_retry: true, uses_transaction: false) do |conn|
+        with_trilogy_connection(allow_retry: true, materialize_transactions: false) do |conn|
           conn.escape(string)
         end
       end
@@ -205,10 +205,10 @@ module ActiveRecord
         end
       end
 
-      def with_trilogy_connection(uses_transaction: true, **_kwargs)
+      def with_trilogy_connection(materialize_transactions: true, **_kwargs)
         @lock.synchronize do
           verify!
-          materialize_transactions if uses_transaction
+          materialize_transactions if materialize_transactions
           yield connection
         end
       end
@@ -325,7 +325,7 @@ module ActiveRecord
         end
 
         def get_full_version
-          with_trilogy_connection(allow_retry: true, uses_transaction: false) do |conn|
+          with_trilogy_connection(allow_retry: true, materialize_transactions: false) do |conn|
             conn.server_info[:version]
           end
         end


### PR DESCRIPTION
**casperisfine** indicates: "It's hard to understand what `uses_transactions` does.", so this PR renames `uses_transactions` to `materialize_transactions`.

(@kamil-gwozdz had originally created PR #39 to bring in rails/rails#48068, and now that there has been a bit more shuffling around, here is a more current version.)