### PR TITLE
correct reference to materialize_transactions in with_trilogy_connection

### DIFF
--- a/lib/active_record/connection_adapters/trilogy_adapter.rb
+++ b/lib/active_record/connection_adapters/trilogy_adapter.rb
@@ -209,7 +209,7 @@ module ActiveRecord
       def with_trilogy_connection(materialize_transactions: true, **_kwargs)
         @lock.synchronize do
           verify!
-          materialize_transactions if materialize_transactions
+          self.materialize_transactions if materialize_transactions
           yield connection
         end
       end


### PR DESCRIPTION
inside the method we need to be explicit that we are calling `materialize_transactions` the method and not `materialize_transactions` the keyword argument.

this fixes https://github.com/trilogy-libraries/activerecord-trilogy-adapter/issues/60