### PR TITLE
Fix merge conflict between #48 and #51

### DIFF
--- a/lib/active_record/connection_adapters/trilogy/database_statements.rb
+++ b/lib/active_record/connection_adapters/trilogy/database_statements.rb
@@ -21,21 +21,6 @@ module ActiveRecord
           ActiveRecord::Result.new(result.fields, result.to_a)
         end
 
-        def write_query?(sql) # :nodoc:
-          !READ_QUERY.match?(sql)
-        rescue ArgumentError # Invalid encoding
-          !READ_QUERY.match?(sql.b)
-        end
-
-        def explain(arel, binds = [])
-          sql     = "EXPLAIN #{to_sql(arel, binds)}"
-          start   = Process.clock_gettime(Process::CLOCK_MONOTONIC)
-          result  = internal_exec_query(sql, "EXPLAIN", binds)
-          elapsed = Process.clock_gettime(Process::CLOCK_MONOTONIC) - start
-
-          MySQL::ExplainPrettyPrinter.new.pp(result, elapsed)
-        end
-
         def select_all(*, **) # :nodoc:
           result = super
           with_trilogy_connection do |conn|


### PR DESCRIPTION
Both #48 and #51 added `write_query?` and `explain`. I removed the duplicate methods that weren't being used, which were the older versions with no options parameter.

The newer `write_query?` and `explain` with the options are still there.