### PR TITLE
Incorporate Rails PR #49378

### DIFF
--- a/lib/active_record/connection_adapters/trilogy_adapter.rb
+++ b/lib/active_record/connection_adapters/trilogy_adapter.rb
@@ -214,6 +214,10 @@ module ActiveRecord
         end
       end
 
+      def connected?
+        !connection.nil?
+      end
+
       def active?
         return false if connection&.closed?
 


### PR DESCRIPTION
Incorporates the `#connected?` method that is found as a part of rails/rails#49378.