### PR TITLE
Allow socket usage in DATABASE_URL

### DIFF
--- a/lib/active_record/connection_adapters/trilogy_adapter.rb
+++ b/lib/active_record/connection_adapters/trilogy_adapter.rb
@@ -155,6 +155,12 @@ module ActiveRecord
       end
 
       def initialize(connection, logger, connection_options, config)
+        config = config.dup
+
+        # Trilogy ignores `socket` if `host` is set. We want the opposite to allow
+        # configuring UNIX domain sockets via `DATABASE_URL`.
+        config.delete(:host) if config[:socket]
+
         super
         # Ensure that we're treating prepared_statements in the same way that Rails 7.1 does
         @prepared_statements = self.class.type_cast_config_to_boolean(

--- a/test/lib/active_record/connection_adapters/trilogy_adapter_test.rb
+++ b/test/lib/active_record/connection_adapters/trilogy_adapter_test.rb
@@ -875,6 +875,13 @@ class ActiveRecord::ConnectionAdapters::TrilogyAdapterTest < TestCase
     assert_equal current_sql_mode, ["STRICT_ALL_TABLES"]
   end
 
+  test "socket has precedence over host" do
+    error = assert_raises ActiveRecord::ConnectionNotEstablished do
+      trilogy_adapter(host: "invalid", port: 12345, socket: "/var/invalid.sock").connect!
+    end
+    assert_includes error.message, "/var/invalid.sock"
+  end
+
   def trilogy_adapter_with_connection(connection, **config_overrides)
     ActiveRecord::ConnectionAdapters::TrilogyAdapter
       .new(connection, nil, {}, @configuration.merge(config_overrides))


### PR DESCRIPTION
Contrary to mysql2, trilogy will ignore the socket config if host is set.

This makes it impossible to configure a UNIX domain socket connection via DATABASE_URL, as the URL must include a host.

This is a backport of rails/rails#50349