### PR TITLE
Update README.md to note that Rails 7.1+ will still need to add trilogy gem to Gemfile

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -11,7 +11,3 @@ end
 gem "trilogy"
 
 gemspec
-
-# Separately require this due to concurrent_ruby 1.3.5 and later removing the
-# dependency to logger
-require "logger"

--- a/Gemfile
+++ b/Gemfile
@@ -11,3 +11,7 @@ end
 gem "trilogy"
 
 gemspec
+
+# Separately require this due to concurrent_ruby 1.3.5 and later removing the
+# dependency to logger
+require "logger"

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ Ruby on Rails Active Record database adapter for [Trilogy](https://github.com/tr
 
 This gem offers Trilogy support for versions of Active Record prior to v7.1. Currently supports:
 
-- ⚠️ Rails v7.1+ includes Trilogy support by default making this gem unnecessary
+- ⚠️ Rails v7.1+ includes Trilogy support by default making this gem unnecessary; do add `gem "trilogy"` to your Gemfile
 - ✅ Rails v7.0.x
 - ✅ Rails v6.1.x
 - ✅ Rails v6.0.x

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ Ruby on Rails Active Record database adapter for [Trilogy](https://github.com/tr
 
 This gem offers Trilogy support for versions of Active Record prior to v7.1. Currently supports:
 
-- ⚠️ Rails v7.1+ includes Trilogy support by default making this gem unnecessary; do add `gem "trilogy"` to your Gemfile
+- ⚠️ Rails v7.1+ includes Trilogy support by default making this gem unnecessary (and still do add `gem "trilogy"` to your Gemfile)
 - ✅ Rails v7.0.x
 - ✅ Rails v6.1.x
 - ✅ Rails v6.0.x


### PR DESCRIPTION
Closes #75 