### PR TITLE
Incorporate error handling of rails/rails#50349

### DIFF
--- a/lib/active_record/connection_adapters/trilogy_adapter.rb
+++ b/lib/active_record/connection_adapters/trilogy_adapter.rb
@@ -80,7 +80,7 @@ module ActiveRecord
         def new_client(config)
           config[:ssl_mode] = parse_ssl_mode(config[:ssl_mode]) if config[:ssl_mode]
           ::Trilogy.new(config)
-        rescue ::Trilogy::ConnectionError, ::Trilogy::ProtocolError => error
+        rescue ::Trilogy::Error => error
           raise translate_connect_error(config, error)
         end
 

--- a/test/lib/active_record/connection_adapters/trilogy_adapter_test.rb
+++ b/test/lib/active_record/connection_adapters/trilogy_adapter_test.rb
@@ -173,25 +173,6 @@ class ActiveRecord::ConnectionAdapters::TrilogyAdapterTest < TestCase
     assert connection.verify
   end
 
-  test "#reconnect doesn't retain old connection on failure" do
-    old_connection = Minitest::Mock.new Trilogy.new(@configuration)
-    old_connection.expect :close, true
-
-    adapter = trilogy_adapter_with_connection(old_connection)
-
-    begin
-      Trilogy.stub(:new, -> _ { raise Trilogy::BaseError.new }) do
-        adapter.reconnect!
-      end
-    rescue Trilogy::BaseError => ex
-      assert_instance_of Trilogy::BaseError, ex
-    else
-      flunk "Expected Trilogy::BaseError to be raised"
-    end
-
-    assert_nil adapter.send(:connection)
-  end
-
   test "#reconnect answers new connection with existing connection" do
     old_connection = @adapter.send(:connection)
     @adapter.reconnect!


### PR DESCRIPTION
This PR ignores the `host` if a `socket` parameter is set.  This allows configuring a connection on a UNIX socket via DATABASE_URL.

This is a slight tweak after #71 