### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,6 +2,9 @@ name: CI
 
 on: [push, pull_request]
 
+permissions:
+  contents: read
+
 jobs:
   test:
     strategy:


### PR DESCRIPTION
Potential fix for [https://github.com/trilogy-libraries/activerecord-trilogy-adapter/security/code-scanning/1](https://github.com/trilogy-libraries/activerecord-trilogy-adapter/security/code-scanning/1)

To fix the issue, we need to add a `permissions` block to the workflow file. Since the workflow does not require write permissions, we can set the permissions to `contents: read`. This ensures that the workflow has only the minimal access required to perform its tasks. The `permissions` block should be added at the root level of the workflow file, so it applies to all jobs unless overridden by job-specific permissions.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
